### PR TITLE
#2 - Only collect button events within the same channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@ class Menu extends events_1.EventEmitter {
      * Start a reaction collector and switch pages where required.
      */
     awaitButtons() {
-        this.buttonCollector = new discord_js_1.InteractionCollector(client, { filter: (i) => i.member.user.id === this.userID && i.isButton(), idle: this.ms, });
+        this.buttonCollector = new discord_js_1.InteractionCollector(client, { filter: (i) => i.member.user.id === this.userID && i.channel.id === this.channel.id && i.isButton(), idle: this.ms });
         // this.menu.createButtonCollector((button: { clicker: { id: any; }; }) => button.clicker.id === this.userID, { idle: this.ms })
         //@ts-ignore
         this.buttonCollector.on("end", (i, reason) => {

--- a/index.ts
+++ b/index.ts
@@ -316,7 +316,7 @@ export class Menu extends EventEmitter {
      * Start an interaction collector and switch pages where required.
      */
     awaitButtons() {
-        this.buttonCollector = new InteractionCollector<ButtonInteraction>(client, { filter: (i) => i.member.user.id === this.userID && i.isButton(), idle: this.ms, })
+        this.buttonCollector = new InteractionCollector<ButtonInteraction>(client, { filter: (i) => i.member.user.id === this.userID && i.channel.id === this.channel.id && i.isButton(), idle: this.ms, })
         // this.menu.createButtonCollector((button: { clicker: { id: any; }; }) => button.clicker.id === this.userID, { idle: this.ms })
 
         //@ts-ignore


### PR DESCRIPTION
This resolves #2 by filtering the ButtonCollector's interactions to the channel the menu lives in.